### PR TITLE
Gets decryption to read ALL bytes

### DIFF
--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -2,12 +2,8 @@
   "profiles": {
     "Macro Deck 2": {
       "commandName": "Project",
-      "commandLineArgs": "--show --export-default-strings --loglevel 1 --test-channel --debug-console",
+      "commandLineArgs": "--show --export-default-strings --loglevel 1 --test-channel --portable --debug-console",
       "nativeDebugging": false
-    },
-    "Macro Deck exe": {
-      "commandName": "Executable",
-      "executablePath": "D:\\Macro-Deck\\Macro Deck 2\\bin\\Debug\\netcoreapp3.1\\Macro Deck 2.exe"
     }
   }
 }

--- a/Utils/StringCipher.cs
+++ b/Utils/StringCipher.cs
@@ -80,11 +80,10 @@ namespace SuchByte.MacroDeck.Utils
                         {
                             using (var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read))
                             {
-                                var plainTextBytes = new byte[cipherTextBytes.Length];
-                                var decryptedByteCount = cryptoStream.Read(plainTextBytes, 0, plainTextBytes.Length);
-                                memoryStream.Close();
-                                cryptoStream.Close();
-                                return Encoding.UTF8.GetString(plainTextBytes, 0, decryptedByteCount);
+                                using (var streamReader = new StreamReader(cryptoStream, Encoding.UTF8))
+                                {
+                                    return streamReader.ReadToEnd();
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
- apprently in .net6 CryptoStream doesn't necessarily read all the bytes you tell it to
- got it workin with a loop
- then replaced that with a simple StreamReader I saw from another place

Also apparently my launchSettings things got in here. I usually just run a portable mode from debug and use that as my test environment. Didn't know if you liked that idea or not. If you want me to revert that, I can.