### PR TITLE
Update Magick dependency

### DIFF
--- a/MacroDeck/MacroDeck.csproj
+++ b/MacroDeck/MacroDeck.csproj
@@ -108,8 +108,7 @@
     <PackageReference Include="Dax-FCTB" Version="2.16.26.120" />
     <PackageReference Include="Fleck" Version="1.2.0" />
     <PackageReference Include="GiphyDotNet" Version="2.0.0" />
-    <PackageReference Include="Magick.NET-Q16-x64" Version="8.3.1" />
-    <PackageReference Include="Magick.NET.Core" Version="8.3.1" />
+    <PackageReference Include="Magick.NET-Q16-x64" Version="12.2.2" />
     <PackageReference Include="Magick.NET.SystemDrawing" Version="4.0.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />


### PR DESCRIPTION
update fixes advisory warnings in outdated library